### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # LAS
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NOAA-PMEL/LAS)
 
 # N.B. There is a serious vulnerabilty in this software ([CVE-2025-62193](https://www.cve.org/CVERecord?id=CVE-2025-62193)).
 # If you are still running LAS 8, you should apply the following fix.


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/NOAA-PMEL/LAS) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.